### PR TITLE
Added a new 'interleaved' ordering group.

### DIFF
--- a/forge/forge.py
+++ b/forge/forge.py
@@ -105,4 +105,7 @@ class Forge(object):
     def ordered(self):
         return self.queue.get_ordered_group_context()
 
+    def interleaved_order(self):
+        return self.queue.get_interleaved_group_context()
+
     group = ordered

--- a/forge/queue.py
+++ b/forge/queue.py
@@ -7,7 +7,7 @@ from .function_call import FunctionCall
 from .setattr import Setattr
 from .exceptions import UnexpectedCall, UnexpectedSetattr, ExpectedEventsNotFound
 from .queued_node import QueuedNode
-from .queued_group import OrderedGroup, AnyOrderGroup
+from .queued_group import OrderedGroup, AnyOrderGroup, InterleavedGroup
 
 _logger = logging.getLogger("pyforge")
 
@@ -106,6 +106,9 @@ class ForgeQueue(object):
 
     def get_ordered_group_context(self):
         return self._get_group_context(OrderedGroup)
+
+    def get_interleaved_group_context(self):
+        return self._get_group_context(InterleavedGroup)
 
     def verify(self):
         expected_events = self._root_group.get_expected()

--- a/forge/queued_group.py
+++ b/forge/queued_group.py
@@ -104,3 +104,19 @@ class AnyOrderGroup(QueuedGroup):
     def __repr__(self):
         return "%s <id %s>(_current_child id=%s, %s, out_of_band=%s)" % (type(self).__name__, id(self),
                     id(self._current_child), repr(self._collection), repr(self._out_of_band_collection))
+
+
+class InterleavedGroup(QueuedGroup):
+    def iter_expected_or_available_children(self):
+        return chain(self._collection, self._out_of_band_collection)
+
+    def _pop_matching_by_strategy(self, queued_object):
+        for obj in self._collection:
+            result = obj.pop_matching(queued_object)
+            if result is not None:
+                return result
+        return None
+
+    def __repr__(self):
+        return "%s <id %s>(%s, out_of_band=%s)" % (type(self).__name__, id(self), repr(self._collection),
+                                                   repr(self._out_of_band_collection))

--- a/tests/test__interleaved.py
+++ b/tests/test__interleaved.py
@@ -1,0 +1,58 @@
+import random
+from .ut_utils import ForgeTestCase
+from forge.exceptions import UnexpectedCall
+
+
+class Obj(object):
+    def f(self, a, b, c):
+        raise NotImplementedError()  # pragma: no cover
+
+    def g(self, value):
+        raise NotImplementedError()  # pragma: no cover
+
+
+class InterleavedTest(ForgeTestCase):
+    def setUp(self):
+        super(InterleavedTest, self).setUp()
+        self.obj = self.forge.create_mock(Obj)
+
+    def test__interleaved__single_collection(self):
+        with self.forge.interleaved_order():
+            self.obj.f(1, 2, 3).and_return(2)
+            self.obj.f(2, 3, 4).and_return(3)
+
+        self.forge.replay()
+        self.assertEquals(self.obj.f(1, 2, 3), 2)
+        with self.assertRaises(UnexpectedCall):
+            self.obj.f(1, 2, 4)
+        self.assertEquals(self.obj.f(2, 3, 4), 3)
+
+    def test__interleaved__two_ordered_nested(self):
+        with self.forge.interleaved_order():
+            with self.forge.ordered():
+                self.obj.f(1, 1, 1).and_return(11)
+                self.obj.f(1, 1, 2).and_return(12)
+                self.obj.f(1, 1, 3).and_return(13)
+
+            with self.forge.ordered():
+                self.obj.f(1, 2, 1).and_return(21)
+                self.obj.f(1, 2, 2).and_return(22)
+                self.obj.f(1, 2, 3).and_return(23)
+
+        self.forge.replay()
+
+        parallels = [
+            [((1, 1, 1), 11), ((1, 1, 2), 12), ((1, 1, 3), 13)],
+            [((1, 2, 1), 21), ((1, 2, 2), 22), ((1, 2, 3), 23)]
+        ]
+
+        while parallels:
+            random.shuffle(parallels)
+            args, ret = parallels[0].pop(0)
+            self.assertEquals(self.obj.f(*args), ret)
+            if not parallels[0]:
+                parallels.pop(0)
+
+    def test__interleaved__zero_context(self):
+        with self.forge.interleaved_order():
+            pass


### PR DESCRIPTION
This ordering group picks the next allowed call to be any one of its nested groups, so given the following:

``` python
with forge.interleaved_order():
    with forge.ordered():
        foo(1)
        foo(2)
    with forge.ordered():
        bar(1)
        bar(2)
```

These sequences are valid:

``` python
foo(1)
bar(1)
foo(2)
bar(2)
```

or:

``` python
bar(1)
bar(2)
foo(1)
foo(2)
```

but this one isn't:

``` python
foo(2) # out of order
foo(1)
bar(1)
bar(2)
```
