### PR TITLE
added syntactic sugar record_context context manager

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,16 @@ Just like classes yield mocks, regular functions yield stubs, through the use of
 
 As methods and functions are recorded, their signature is verified against the recorded calls. Upon replay the call must match the original call, so you shouldn't worry too much about accidents concerning the function signature.
 
+To promote niceness, two context managers provide syntactic sugar that structure the test code:
+
+ >>> with forge_manager.record_context():
+ ...    mock.f(1, 2, 3) # doctest: +ELLIPSIS
+ ...    mock.f(3, 4, 5) # doctest: +ELLIPSIS
+ <...>
+ >>> with forge_manager.verified_replay_context():
+ ...    mock.f(1, 2, 3) # doctest: +ELLIPSIS
+ ...    mock.f(3, 4, 5) # doctest: +ELLIPSIS
+
 Failures and Unexpected Events
 ------------------------------
 Whenever an event occurs that was not expected, an exception is raised, explaining what happend::

--- a/forge/forge.py
+++ b/forge/forge.py
@@ -41,6 +41,11 @@ class Forge(object):
         self.attributes.reset_replay_attributes()
 
     @contextmanager
+    def record_context(self):
+        assert self.is_recording()
+        yield
+
+    @contextmanager
     def verified_replay_context(self):
         self.replay()
         yield


### PR DESCRIPTION
With the record_context() syntactic sugar and Python's indentation the separation between record phase and replay phase is easily seen:

``` python
with forge.record_context():
    write_expectations()
    more_expectations()

with forge.verified_replay_context():
    do_stuff_that_trigger_expectations()
```
