### PR TITLE
Update to assertEqual in test suite

### DIFF
--- a/tests/test__actions.py
+++ b/tests/test__actions.py
@@ -9,9 +9,9 @@ class ActionsTest(ForgeTestCase):
         self.stub = self.forge.create_function_stub(lambda *args, **kwargs: None)
     def test__return_value(self):
         rv = self.stub(1, 2, 3).and_return(666)
-        self.assertEquals(rv, 666)
+        self.assertEqual(rv, 666)
         self.forge.replay()
-        self.assertEquals(666, self.stub(1, 2, 3))
+        self.assertEqual(666, self.stub(1, 2, 3))
         self.assertNoMoreCalls()
         self.forge.verify()
     def test__raised_exception(self):
@@ -30,7 +30,7 @@ class ActionsTest(ForgeTestCase):
         with self.assertRaises(ConflictingActions):
             expected_call.and_raise(Exception())
         #conflict should not affect existing expectations
-        self.assertEquals(expected_call._return_value, 2)
+        self.assertEqual(expected_call._return_value, 2)
         self.assertIs(expected_call._raised_exception, NOTHING)
 
         expected_call = self.stub(1, 2, 3)
@@ -46,34 +46,34 @@ class ActionsTest(ForgeTestCase):
         return_value = 666
         cp = Checkpoint()
         rv = self.stub(1, 2, 3).and_call(cp.trigger).and_return(return_value)
-        self.assertEquals(rv, return_value)
+        self.assertEqual(rv, return_value)
         self.forge.replay()
         rv = self.stub(1, 2, 3)
-        self.assertEquals(rv, return_value)
+        self.assertEqual(rv, return_value)
         self.assertTrue(cp.called)
     def test__and_call__specify_args_kwargs(self):
         return_value = 666
         cp = Checkpoint()
         def callback(a, b, c, d):
-            self.assertEquals((a, b, c, d), (1, 2, 3, 4))
+            self.assertEqual((a, b, c, d), (1, 2, 3, 4))
             cp.trigger()
         rv = self.stub(1, 2, 3).and_call(callback, args=(1, 2, 3), kwargs=dict(d=4)).and_return(return_value)
-        self.assertEquals(rv, return_value)
+        self.assertEqual(rv, return_value)
         self.forge.replay()
         rv = self.stub(1, 2, 3)
-        self.assertEquals(rv, return_value)
+        self.assertEqual(rv, return_value)
         self.assertTrue(cp.called)
 
     def test__and_call_with_args(self):
         return_value = 666
         cp = Checkpoint()
         def trigger(*args, **kwargs):
-            self.assertEquals(args, (1, 2, 3))
-            self.assertEquals(kwargs, dict(d=4))
+            self.assertEqual(args, (1, 2, 3))
+            self.assertEqual(kwargs, dict(d=4))
             cp.trigger()
         rv = self.stub(1, 2, 3, d=4).and_call_with_args(trigger).and_return(return_value)
-        self.assertEquals(rv, return_value)
+        self.assertEqual(rv, return_value)
         self.forge.replay()
         rv = self.stub(1, 2, 3, d=4)
-        self.assertEquals(rv, return_value)
+        self.assertEqual(rv, return_value)
         self.assertTrue(cp.called)

--- a/tests/test__comparators.py
+++ b/tests/test__comparators.py
@@ -27,7 +27,7 @@ class _ComparatorTest(TestCase):
         for a, _ in itertools.chain(self._get_equal_pairs(), self._get_unequal_pairs()):
             self.assertIsInstance(a, Comparator)
             self.assertIsInstance(str(a), basestring)
-            self.assertEquals(str(a), repr(a))
+            self.assertEqual(str(a), repr(a))
 
 class IsTest(_ComparatorTest):
     def _get_equal_pairs(self):

--- a/tests/test__context_managers.py
+++ b/tests/test__context_managers.py
@@ -34,14 +34,14 @@ class ContextManagerTest(ForgeTestCase):
             with self.obj:
                 raise my_exception
         caught = caught.exception
-        self.assertEquals(len(caught.expected), 1)
+        self.assertEqual(len(caught.expected), 1)
         self.assertIs(caught.expected[0].target, self.checkpoint)
         self.assertIsSameMethod(caught.got.target.__forge__.original,
                                 ContextManager.__exit__)
         self.assertIs(caught.got.args['t'], Exception)
         self.assertIs(caught.got.args['v'], my_exception)
         self.assertIsNotNone(caught.got.args['tb'])
-        self.assertEquals(len(self.forge.queue), 2)
+        self.assertEqual(len(self.forge.queue), 2)
         self.forge.reset()
     def test__expecting_context_with_unexpected_call_inside(self):
         stub = self.forge.create_function_stub(lambda arg: None)
@@ -52,12 +52,12 @@ class ContextManagerTest(ForgeTestCase):
             with self.obj:
                 stub(2)
         caught = caught.exception
-        self.assertEquals(len(caught.expected), 1)
+        self.assertEqual(len(caught.expected), 1)
         self.assertIs(caught.expected[0].target, stub)
         self.assertIs(caught.got.target, stub)
         self.assertIs(caught.expected[0].args['arg'], 1)
         self.assertIs(caught.got.args['arg'], 2)
-        self.assertEquals(len(self.forge.queue), 2)
+        self.assertEqual(len(self.forge.queue), 2)
         self.forge.reset()
     def test__expecting_context_with_unexpected_setattr_inside(self):
         with self.obj:
@@ -67,14 +67,14 @@ class ContextManagerTest(ForgeTestCase):
             with self.obj:
                 self.obj.a = 2
         caught = caught.exception
-        self.assertEquals(len(caught.expected), 1)
+        self.assertEqual(len(caught.expected), 1)
         self.assertIs(caught.expected[0].target, self.obj.__forge__.get_attribute('__exit__'))
-        self.assertEquals(len(caught.expected[0].args), 3)
+        self.assertEqual(len(caught.expected[0].args), 3)
         self.assertTrue(all(x is None for x in caught.expected[0].args.values()))
         self.assertIs(caught.got.target, self.obj)
-        self.assertEquals(caught.got.name, 'a')
-        self.assertEquals(caught.got.value, 2)
-        self.assertEquals(len(self.forge.queue), 1)
+        self.assertEqual(caught.got.name, 'a')
+        self.assertEqual(caught.got.value, 2)
+        self.assertEqual(len(self.forge.queue), 1)
         self.forge.reset()
     def test__enter_returning_value(self):
         self.obj.__enter__().and_return(2)
@@ -83,7 +83,7 @@ class ContextManagerTest(ForgeTestCase):
         self.forge.replay()
         with self.obj as value:
             self.checkpoint()
-        self.assertEquals(value, 2)
+        self.assertEqual(value, 2)
     def assertIsSameMethod(self, a, b):
         if IS_PY3:
             if not isinstance(a, types.FunctionType):

--- a/tests/test__function_stubs.py
+++ b/tests/test__function_stubs.py
@@ -19,19 +19,19 @@ class FunctionStubbingTest(ForgeTestCase):
         urlopen_stub = self.forge.create_function_stub(urlopen)
         urlopen_stub("url").and_return(666)
         self.forge.replay()
-        self.assertEquals(urlopen_stub("url"), 666)
+        self.assertEqual(urlopen_stub("url"), 666)
 
 class FunctionStubAttributesTest(ForgeTestCase):
     def setUp(self):
         super(FunctionStubAttributesTest, self).setUp()
         self.stub = self.forge.create_function_stub(some_function)
     def test__name(self):
-        self.assertEquals(self.stub.__name__, some_function.__name__)
+        self.assertEqual(self.stub.__name__, some_function.__name__)
     def test__specific_name(self):
         stub = self.forge.create_function_stub(some_function, name='other_name')
-        self.assertEquals(stub.__name__, 'other_name')
+        self.assertEqual(stub.__name__, 'other_name')
     def test__doc(self):
-        self.assertEquals(self.stub.__doc__, some_function.__doc__)
+        self.assertEqual(self.stub.__doc__, some_function.__doc__)
     def test__stub_id(self):
         self.assertIsInstance(self.stub.__forge__.id, Number)
     def test__str_repr(self):

--- a/tests/test__hybrid_mock.py
+++ b/tests/test__hybrid_mock.py
@@ -67,7 +67,7 @@ class HybridMockTest(ForgeTestCase):
         hm.__forge__.enable_setattr_during_replay()
         self.forge.replay()
         hm.set_value()
-        self.assertEquals(hm.value, 2)
+        self.assertEqual(hm.value, 2)
 
 class ClassWithClassmethodConstructor(object):
     def __init__(self, a, b, c):

--- a/tests/test__interleaved.py
+++ b/tests/test__interleaved.py
@@ -24,10 +24,10 @@ class InterleavedTest(ForgeTestCase):
             self.obj.f(2, 3, 4).and_return(3)
 
         self.forge.replay()
-        self.assertEquals(self.obj.f(1, 2, 3), 2)
+        self.assertEqual(self.obj.f(1, 2, 3), 2)
         with self.assertRaises(UnexpectedCall):
             self.obj.f(1, 2, 4)
-        self.assertEquals(self.obj.f(2, 3, 4), 3)
+        self.assertEqual(self.obj.f(2, 3, 4), 3)
 
     def test__interleaved__two_ordered_nested(self):
         with self.forge.interleaved_order():
@@ -58,7 +58,7 @@ class InterleavedTest(ForgeTestCase):
                     self.obj.f(*thread[1][0])
 
             args, ret = thread.pop(0)
-            self.assertEquals(self.obj.f(*args), ret)
+            self.assertEqual(self.obj.f(*args), ret)
             if not thread:
                 parallels.pop(0)
 

--- a/tests/test__mock_attributes.py
+++ b/tests/test__mock_attributes.py
@@ -22,7 +22,7 @@ class MockAttributesTest(ForgeTestCase):
         self.forge.replay()
         self.assertIs(self.obj.a, attr_value)
         self.forge.reset()
-        self.assertEquals(self.obj.a, attr_value)
+        self.assertEqual(self.obj.a, attr_value)
     def test__setting_mock_object_attributes_during_replay(self):
         self.forge.replay()
         with self.assertUnexpectedSetattr(self.obj, "a", 2):
@@ -36,7 +36,7 @@ class MockAttributesTest(ForgeTestCase):
         self.obj.__forge__.enable_setattr_during_replay()
         self.forge.replay()
         self.obj.a = 2
-        self.assertEquals(self.obj.a, 2)
+        self.assertEqual(self.obj.a, 2)
         self.forge.reset()
         with self.assertRaises(AttributeError):
             self.obj.a
@@ -52,9 +52,9 @@ class MockAttributesTest(ForgeTestCase):
         with self.assertUnexpectedSetattr(self.obj, "a", 3):
             self.obj.a = 3
         self.assertNoMoreCalls()
-        self.assertEquals(self.obj.a, 2)
+        self.assertEqual(self.obj.a, 2)
         self.forge.reset()
-        self.assertEquals(self.obj.a, 2)
+        self.assertEqual(self.obj.a, 2)
     def test__getattr_of_nonexisting_attr_during_replay(self):
         self.forge.replay()
         with self.assertRaises(AttributeError):
@@ -67,15 +67,15 @@ class MockAttributesTest(ForgeTestCase):
         self.forge.replay()
         self.obj.some_method
     def test__getattr_of_class_variables_during_record(self):
-        self.assertEquals(self.obj.class_variable, MockedClass.class_variable)
+        self.assertEqual(self.obj.class_variable, MockedClass.class_variable)
     def test__getattr_of_class_variables_during_replay(self):
         self.forge.replay()
-        self.assertEquals(self.obj.class_variable, MockedClass.class_variable)
+        self.assertEqual(self.obj.class_variable, MockedClass.class_variable)
     def test__setattr_of_class_variables_during_record(self):
         self.obj.class_variable = 300
-        self.assertEquals(self.obj.class_variable, 300)
+        self.assertEqual(self.obj.class_variable, 300)
         self.forge.replay()
-        self.assertEquals(self.obj.class_variable, 300)
+        self.assertEqual(self.obj.class_variable, 300)
     def test__setattr_of_class_variables_during_replay(self):
         self.forge.replay()
         with self.assertUnexpectedSetattr(self.obj, "class_variable", 300):
@@ -86,28 +86,28 @@ class MockAttributesTest(ForgeTestCase):
         with self.assertRaises(AttributeError):
             self.obj.a
         self.obj.a = 666
-        self.assertEquals(self.obj.a, 666)
+        self.assertEqual(self.obj.a, 666)
     def test__expect_setattr_previous_value(self):
         self.obj.a = 1
-        self.assertEquals(self.obj.a, 1)
+        self.assertEqual(self.obj.a, 1)
         self.obj.__forge__.expect_setattr("a", 2)
-        self.assertEquals(self.obj.a, 1)
+        self.assertEqual(self.obj.a, 1)
         self.forge.replay()
-        self.assertEquals(self.obj.a, 1)
+        self.assertEqual(self.obj.a, 1)
         self.obj.a = 2
-        self.assertEquals(self.obj.a, 2)
+        self.assertEqual(self.obj.a, 2)
         self.assertNoMoreCalls()
         self.forge.reset()
-        self.assertEquals(self.obj.a, 1)
+        self.assertEqual(self.obj.a, 1)
     def test__expect_setattr_not_happening(self):
         self.obj.__forge__.expect_setattr("a", 666)
         self.forge.replay()
         with self.assertRaises(ExpectedEventsNotFound) as caught:
             self.forge.verify()
-        self.assertEquals(len(caught.exception.events), 1)
+        self.assertEqual(len(caught.exception.events), 1)
         self.assertIs(caught.exception.events[0].target, self.obj)
-        self.assertEquals(caught.exception.events[0].name, "a")
-        self.assertEquals(caught.exception.events[0].value, 666)
+        self.assertEqual(caught.exception.events[0].name, "a")
+        self.assertEqual(caught.exception.events[0].value, 666)
         self.forge.reset()
     @contextmanager
     def assertUnexpectedSetattr(self, target, name, value):
@@ -115,8 +115,8 @@ class MockAttributesTest(ForgeTestCase):
             yield None
         exception = caught.exception
         self.assertIs(exception.got.target, target)
-        self.assertEquals(exception.got.name, name)
-        self.assertEquals(exception.got.value, value)
+        self.assertEqual(exception.got.name, name)
+        self.assertEqual(exception.got.value, value)
 
 
 

--- a/tests/test__mocking_instances.py
+++ b/tests/test__mocking_instances.py
@@ -71,8 +71,8 @@ class MockingCornerCasesTest(ForgeTestCase):
         with self.assertRaises(AttributeError):
             mock.gettt
         self.forge.replay()
-        self.assertEquals(mock.get(2, 3), 4)
-        self.assertEquals(mock[6], 7)
+        self.assertEqual(mock.get(2, 3), 4)
+        self.assertEqual(mock[6], 7)
 
 class InvalidMockingTest(ForgeTestCase):
     def test__cannot_mock_functions(self):

--- a/tests/test__readme.py
+++ b/tests/test__readme.py
@@ -7,4 +7,4 @@ class ReadmeTest(TestCase):
         readme_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "README.rst"))
         self.assertTrue(os.path.exists(readme_path))
         result = doctest.testfile(readme_path, module_relative=False)
-        self.assertEquals(result.failed, 0, "%s tests failed!" % result.failed)
+        self.assertEqual(result.failed, 0, "%s tests failed!" % result.failed)

--- a/tests/test__record_replay.py
+++ b/tests/test__record_replay.py
@@ -21,15 +21,15 @@ class RecordReplayTest(ForgeTestCase):
         for i in range(2):
             self.stub(1, 2, 3)
             self.stub(1, 2, 3)
-        self.assertEquals(self.stub.__forge__.call_count, 0)
+        self.assertEqual(self.stub.__forge__.call_count, 0)
         self.forge.replay()
         self.stub(1, 2, 3)
-        self.assertEquals(self.stub.__forge__.call_count, 1)
+        self.assertEqual(self.stub.__forge__.call_count, 1)
         self.stub(1, 2, 3)
-        self.assertEquals(self.stub.__forge__.call_count, 2)
+        self.assertEqual(self.stub.__forge__.call_count, 2)
         self.assertIn("2 times", str(self.stub))
         self.forge.reset()
-        self.assertEquals(self.stub.__forge__.call_count, 0)
+        self.assertEqual(self.stub.__forge__.call_count, 0)
 
     def test__record_replay_different_not_equal_value(self):
         self.stub(1, 2, 3)
@@ -37,9 +37,9 @@ class RecordReplayTest(ForgeTestCase):
         with self.assertRaises(UnexpectedCall) as caught:
             self.stub(1, 2, 6)
         exc = caught.exception
-        self.assertEquals(len(exc.expected), 1)
-        self.assertEquals(exc.expected[0].args, dict(a=1, b=2, c=3))
-        self.assertEquals(exc.got.args, dict(a=1, b=2, c=6))
+        self.assertEqual(len(exc.expected), 1)
+        self.assertEqual(exc.expected[0].args, dict(a=1, b=2, c=3))
+        self.assertEqual(exc.got.args, dict(a=1, b=2, c=6))
         self.assertExpectedNotMet([self.stub])
     def test__record_replay_different_more_args(self):
         self.stub(1, 2, 3)
@@ -64,7 +64,7 @@ class RecordReplayTest(ForgeTestCase):
         self.stub(1, 2, 3)
         with self.assertRaises(UnexpectedCall) as caught:
             self.stub(1, 2, 3)
-        self.assertEquals(caught.exception.expected, [])
+        self.assertEqual(caught.exception.expected, [])
         self.assertIs(caught.exception.got.target, self.stub)
         self.assertNoMoreCalls()
         self.forge.verify()
@@ -96,11 +96,11 @@ class RecordReplayTest(ForgeTestCase):
         self.assertGreater(len(stubs), 0)
         with self.assertRaises(ExpectedEventsNotFound) as caught:
             self.forge.verify()
-        self.assertEquals(len(caught.exception.events), len(stubs))
+        self.assertEqual(len(caught.exception.events), len(stubs))
         expected = self.forge.queue.get_expected()
         for stub, exception_call in zip(stubs, caught.exception.events):
             expected_call = expected.pop()
             self.assertIs(expected_call, exception_call)
             self.assertIs(expected_call.target, stub)
-        self.assertEquals(len(expected), 0)
+        self.assertEqual(len(expected), 0)
         self.forge.queue.clear()

--- a/tests/test__record_replay_ordering.py
+++ b/tests/test__record_replay_ordering.py
@@ -15,7 +15,7 @@ class StrictOrderingTest(OrderingTest):
         with self.assertRaises(UnexpectedCall) as caught:
             self.stub(2)
         self.assertIs(caught.exception.got.target, self.stub)
-        self.assertEquals(len(caught.exception.expected), 1)
+        self.assertEqual(len(caught.exception.expected), 1)
         self.assertIs(caught.exception.expected[0].target, self.stub)
         self.forge.reset()
 

--- a/tests/test__replacing.py
+++ b/tests/test__replacing.py
@@ -100,7 +100,7 @@ class StubbingModulesTest(ForgeTestCase):
         expected_result = 666
         time.sleep(10).and_return(expected_result)
         self.forge.replay()
-        self.assertEquals(time.sleep(10), expected_result)
+        self.assertEqual(time.sleep(10), expected_result)
         self.forge.restore_all_replacements()
         self.assertIs(time.sleep, orig_time_sleep)
     def test__stub_module_functions(self):
@@ -111,7 +111,7 @@ class StubbingModulesTest(ForgeTestCase):
         return_path = "return_path"
         os.path.join("a", "b", "c").and_return(return_path)
         self.forge.replay()
-        self.assertEquals(return_path, os.path.join("a", "b", "c"))
+        self.assertEqual(return_path, os.path.join("a", "b", "c"))
         self.forge.verify()
         self.forge.restore_all_replacements()
         self.assertIs(os.path.join, orig_os_path_join)
@@ -121,17 +121,17 @@ class ReplacingTest(ForgeTestCase):
         s = self.forge.create_sentinel()
         s.a = 2
         self.forge.replace_with(s, "a", 3)
-        self.assertEquals(s.a, 3)
+        self.assertEqual(s.a, 3)
         self.forge.restore_all_replacements()
-        self.assertEquals(s.a, 2)
+        self.assertEqual(s.a, 2)
     def test__replacing_properties__new_style(self):
         self._test__replacing_properties(NewStyleClass, orig_newstyle_property)
     def test__replacing_properties__old_style(self):
         self._test__replacing_properties(OldStyleClass, orig_oldstyle_property)
     def _test__replacing_properties(self, cls, orig):
         self.forge.replace_with(cls, "some_property", 3)
-        self.assertEquals(cls.some_property, 3)
-        self.assertEquals(cls().some_property, 3)
+        self.assertEqual(cls.some_property, 3)
+        self.assertEqual(cls().some_property, 3)
         self.forge.restore_all_replacements()
         self.assertIs(cls.some_property, orig)
         self.assertIs(cls().some_property, 2)
@@ -189,7 +189,7 @@ class MultipleStubbingTest(ForgeTestCase):
         self.forge.replay()
 
         returned = self.forge.replace_many(some_object, "a", "b", "c")
-        self.assertEquals(returned, expected_results)
+        self.assertEqual(returned, expected_results)
         self.forge.restore_all_replacements()
         self.forge.verify()
         self.assertNoMoreCalls()

--- a/tests/test__sentinels.py
+++ b/tests/test__sentinels.py
@@ -13,8 +13,8 @@ class SentinelTest(ForgeTestCase):
         self.assertIn('s1', repr(s1))
     def test__sentinal_attrs(self):
         s = self.forge.create_sentinel('name1', a=2, b=3, name='name2')
-        self.assertEquals(s.a, 2)
-        self.assertEquals(s.b, 3)
+        self.assertEqual(s.a, 2)
+        self.assertEqual(s.b, 3)
         for s in (str(s), repr(s)):
             self.assertIn('name1', s)
             self.assertNotIn('name2', s)

--- a/tests/test__signature_object.py
+++ b/tests/test__signature_object.py
@@ -12,7 +12,7 @@ class ExpectedArg(object):
 
 class SignatureTest(TestCase):
     def _assert_argument_names(self, sig, names):
-        self.assertEquals([arg.name for arg in sig._args], names)
+        self.assertEqual([arg.name for arg in sig._args], names)
 
     def _test_function_signature(self,
         func,
@@ -22,19 +22,19 @@ class SignatureTest(TestCase):
         ):
         sig = FunctionSignature(func)
 
-        self.assertEquals(len(expected_signature), len(sig._args))
-        self.assertEquals(len(expected_signature), sig.get_num_args())
+        self.assertEqual(len(expected_signature), len(sig._args))
+        self.assertEqual(len(expected_signature), sig.get_num_args())
         for expected_arg, arg in zip(expected_signature, sig._args):
             if isinstance(expected_arg, tuple):
                 expected_arg = ExpectedArg(*expected_arg)
-            self.assertEquals(expected_arg.name,
+            self.assertEqual(expected_arg.name,
                               arg.name)
-            self.assertEquals(expected_arg.has_default,
+            self.assertEqual(expected_arg.has_default,
                               arg.has_default())
             if expected_arg.has_default:
-                self.assertEquals(expected_arg.default, arg.default)
-        self.assertEquals(sig.has_variable_kwargs(), has_varkwargs)
-        self.assertEquals(sig.has_variable_args(), has_varargs)
+                self.assertEqual(expected_arg.default, arg.default)
+        self.assertEqual(sig.has_variable_kwargs(), has_varkwargs)
+        self.assertEqual(sig.has_variable_args(), has_varargs)
 
     def test__simple_functions(self):
         def f(a, b, c):
@@ -128,7 +128,7 @@ class SignatureTest(TestCase):
 class BinaryFunctionSignatureTest(TestCase):
     def test__binary_global_function(self):
         sig = FunctionSignature(time.time)
-        self.assertEquals(sig._args, [])
+        self.assertEqual(sig._args, [])
         self.assertTrue(sig.has_variable_args())
         self.assertTrue(sig.has_variable_kwargs())
     def test__object_method_placeholders(self):

--- a/tests/test__special_methods.py
+++ b/tests/test__special_methods.py
@@ -28,7 +28,7 @@ class _SpecialMethodsTest(ForgeTestCase):
     def test__len(self):
         self.obj.__len__().and_return(2)
         self.forge.replay()
-        self.assertEquals(len(self.obj), 2)
+        self.assertEqual(len(self.obj), 2)
     def test__setitem_explicit(self):
         self.obj.__setitem__('a', 'b')
         self.forge.replay()
@@ -42,22 +42,22 @@ class _SpecialMethodsTest(ForgeTestCase):
         self.forge.replay()
         with self.assertRaises(UnexpectedCall):
             self.obj['a'] = 'c'
-        self.assertEquals(len(self.forge.queue), 1)
+        self.assertEqual(len(self.forge.queue), 1)
         self.forge.reset()
     def test__getitem_explicit(self):
         self.obj.__getitem__(2).and_return(3)
         self.forge.replay()
-        self.assertEquals(self.obj[2], 3)
+        self.assertEqual(self.obj[2], 3)
     def test__getitem_implicit(self):
         self.obj[2].and_return(3)
         self.forge.replay()
-        self.assertEquals(self.obj[2], 3)
+        self.assertEqual(self.obj[2], 3)
     def test__getitem_mismatch(self):
         self.obj[2].and_return(3)
         self.forge.replay()
         with self.assertRaises(UnexpectedCall):
             self.obj[3]
-        self.assertEquals(len(self.forge.queue), 1)
+        self.assertEqual(len(self.forge.queue), 1)
         self.forge.reset()
     def test__delitem_explicit(self):
         self.obj.__delitem__(2)
@@ -72,24 +72,24 @@ class _SpecialMethodsTest(ForgeTestCase):
         self.forge.replay()
         with self.assertRaises(UnexpectedCall):
             del self.obj[3]
-        self.assertEquals(len(self.forge.queue), 1)
+        self.assertEqual(len(self.forge.queue), 1)
         self.forge.reset()
     def test__iter(self):
         expected_result = [1, 3, 4, 5]
         self.obj.__iter__().and_return(iter(expected_result))
         self.forge.replay()
         l = [x for x in self.obj]
-        self.assertEquals(l, expected_result)
+        self.assertEqual(l, expected_result)
     def test__call(self):
         self.obj(1, 2, c=3).and_return(5)
         self.forge.replay()
-        self.assertEquals(self.obj(1, 2, c=3), 5)
+        self.assertEqual(self.obj(1, 2, c=3), 5)
     def test__call_mismatch(self):
         self.obj(1, 2, c=3).and_return(5)
         self.forge.replay()
         with self.assertRaises(UnexpectedCall):
             self.obj(1, 2, c=4)
-        self.assertEquals(len(self.forge.queue), 1)
+        self.assertEqual(len(self.forge.queue), 1)
         self.forge.reset()
     def test__contains_explicit(self):
         self.obj.__contains__(2).and_return(True)
@@ -102,7 +102,7 @@ class _SpecialMethodsTest(ForgeTestCase):
         self.forge.replay()
         with self.assertRaises(UnexpectedCall):
             3 in self.obj
-        self.assertEquals(len(self.forge.queue), 1)
+        self.assertEqual(len(self.forge.queue), 1)
         self.forge.reset()
     def test__boolean(self):
         if IS_PY3:

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -4,7 +4,7 @@ from forge.class_mock_handle import ClassMockHandle
 
 class RenumerateTest(TestCase):
     def test__simple_usage(self):
-        self.assertEquals(list(renumerate(range(5))),
+        self.assertEqual(list(renumerate(range(5))),
                           [(4, 4), (3, 3), (2, 2), (1, 1), (0, 0)])
 
 class EXPECTING_Test(ForgeTestCase):

--- a/tests/test__whenever.py
+++ b/tests/test__whenever.py
@@ -15,10 +15,10 @@ class WheneverTest(ForgeTestCase):
     def test__whenever_verifies_arguments(self):
         self.obj.f(1, 2, 3).whenever().and_return(2)
         self.forge.replay()
-        self.assertEquals(self.obj.f(1, 2, 3), 2)
+        self.assertEqual(self.obj.f(1, 2, 3), 2)
         with self.assertRaises(UnexpectedCall):
             self.obj.f(1, 2, 4)
-        self.assertEquals(self.obj.f(1, 2, 3), 2)
+        self.assertEqual(self.obj.f(1, 2, 3), 2)
     def test__whenever_accepts_zero_times(self):
         self.obj.f(1, 2, 3).whenever().and_return(2)
         self.forge.replay()
@@ -38,12 +38,12 @@ class WheneverTest(ForgeTestCase):
         call.whenever().and_return("hey")
         self.forge.replay()
         for i in range(3):
-            self.assertEquals("hey", self.obj.f(1, 2, 3))
-        self.assertEquals(1, self.obj.f(1, 1, 1))
-        self.assertEquals("hey", self.obj.f(1, 2, 3))
-        self.assertEquals(2, self.obj.f(2, 2, 2))
-        self.assertEquals(3, self.obj.f(3, 3, 3))
-        self.assertEquals("hey", self.obj.f(1, 2, 3))
+            self.assertEqual("hey", self.obj.f(1, 2, 3))
+        self.assertEqual(1, self.obj.f(1, 1, 1))
+        self.assertEqual("hey", self.obj.f(1, 2, 3))
+        self.assertEqual(2, self.obj.f(2, 2, 2))
+        self.assertEqual(3, self.obj.f(3, 3, 3))
+        self.assertEqual("hey", self.obj.f(1, 2, 3))
     def test__whenever_patterns(self):
         values = list(range(10))
         for value in values:
@@ -52,15 +52,15 @@ class WheneverTest(ForgeTestCase):
         for i in range(3):
             random.shuffle(values)
             for value in values:
-                self.assertEquals(self.obj.g(value), value * 2)
+                self.assertEqual(self.obj.g(value), value * 2)
         with self.assertRaises(UnexpectedCall):
             self.obj.g(max(values)+1)
     def test__whenever_when_syntax(self):
         self.obj.g.when(1).then_return(2)
         self.forge.replay()
-        self.assertEquals(self.obj.g(1), 2)
-        self.assertEquals(self.obj.g(1), 2)
-        self.assertEquals(self.obj.g(1), 2)
+        self.assertEqual(self.obj.g(1), 2)
+        self.assertEqual(self.obj.g(1), 2)
+        self.assertEqual(self.obj.g(1), 2)
         with self.assertRaises(UnexpectedCall):
             self.obj.g(2)
     def test__whenever_when_syntax_disabled_in_replay(self):
@@ -76,13 +76,13 @@ class WheneverTest(ForgeTestCase):
             self.obj.f(3, 2, 1).and_return(24)
             self.obj.g.when(1).then_return(3)
         self.forge.replay()
-        self.assertEquals(self.obj.g(1), 2)
-        self.assertEquals(self.obj.g(1), 2)
-        self.assertEquals(self.obj.f(1, 2, 3), 42)
+        self.assertEqual(self.obj.g(1), 2)
+        self.assertEqual(self.obj.g(1), 2)
+        self.assertEqual(self.obj.f(1, 2, 3), 42)
 
-        self.assertEquals(self.obj.g(1), 3)
-        self.assertEquals(self.obj.g(1), 3)
-        self.assertEquals(self.obj.f(3, 2, 1), 24)
+        self.assertEqual(self.obj.g(1), 3)
+        self.assertEqual(self.obj.g(1), 3)
+        self.assertEqual(self.obj.f(3, 2, 1), 24)
     def test__whenever_applies_only_in_group(self):
         result = object()
         with self.forge.ordered():

--- a/tests/test__wildcards.py
+++ b/tests/test__wildcards.py
@@ -44,7 +44,7 @@ class WildcardTest(ForgeTestCase):
         wc = self.forge.create_wildcard_mock()
         wc.a = 2
         self.forge.replay()
-        self.assertEquals(wc.a, 2)
+        self.assertEqual(wc.a, 2)
         with self.assertRaises(UnexpectedSetattr):
             wc.a = 2
         with self.assertRaises(UnexpectedSetattr):
@@ -56,7 +56,7 @@ class WildcardTest(ForgeTestCase):
         wc.__forge__.expect_setattr("a", 2)
         self.forge.replay()
         wc.a = 2
-        self.assertEquals(wc.a, 2)
+        self.assertEqual(wc.a, 2)
     def test__repr(self):
         name = 'some_name'
         wc = self.forge.create_wildcard_mock(name)
@@ -77,5 +77,5 @@ class WildcardTest(ForgeTestCase):
         self.forge.replay()
         with wc:
             f()
-        self.assertEquals(len(wc), 666)
-        self.assertEquals([x for x in wc], list(range(10)))
+        self.assertEqual(len(wc), 666)
+        self.assertEqual([x for x in wc], list(range(10)))

--- a/tests/ut_utils/__init__.py
+++ b/tests/ut_utils/__init__.py
@@ -29,7 +29,7 @@ class ForgeTestCase(TestCase):
         super(ForgeTestCase, self).tearDown()
     def assertNoMoreCalls(self):
         expected = self.forge.queue.get_expected()
-        self.assertEquals(len(expected), 0, "len=%d != 0, expected_events=%s, queue=%s" % (len(expected),
+        self.assertEqual(len(expected), 0, "len=%d != 0, expected_events=%s, queue=%s" % (len(expected),
             repr(expected), repr(self.forge.queue)))
 
 class Method(object):


### PR DESCRIPTION
Silence lots of DeprecationWarning messages by updating from assertEquals
to assertEqual.